### PR TITLE
AilMWeb和OurTV 两个站点发布的名称季数和tmdb不匹配，需修正

### DIFF
--- a/Words/anime.txt
+++ b/Words/anime.txt
@@ -198,6 +198,8 @@ Swallowed.Star.S02 => Swallowed.Star.S01
 吞噬星空.第3季.Swallowed.Star.S03 => Swallowed.Star.S01
 吞噬星空.Swallowed.Star.S04 => Swallowed.Star.S01 && S01 <> 2023 >> EP+85
 Swallowed.Star.2023.S04(?=.*PTerWEB) => Swallowed.Star.S01 && S01 <> WEB-DL >> EP+85
+Swallowed Star 2025 S06(?=.*AilMWeb) => Swallowed.Star.S01
+Swallowed Star 2021 E167(?=.*OurTV) => Swallowed.Star.S01
 
 #百炼成神
 (?<=Apotheosis.S02.*?)2023 => 2022


### PR DESCRIPTION
Swallowed Star 2025 S06(?=.*AilMWeb) => Swallowed.Star.S01 Swallowed Star 2021 E167(?=.*OurTV) => Swallowed.Star.S01

Swallowed Star 2025 S06E165-E166 2160p WEB-DL H265 DDP2.0-AilMWeb  Swallowed Star 2021 E167 2160p WEB-DL H265 AAC-OurTV 两个站点发布的种子文件 对应tmdb中第一季，集数相同